### PR TITLE
Added word for Albanians

### DIFF
--- a/lib/categories/racism.js
+++ b/lib/categories/racism.js
@@ -126,5 +126,8 @@ module.exports = [
   }, {
     description: '"{word}" is a Pacific Islander/Latin American cross ethnic slur',
     words: ['coconut']
+  }, {
+    description: '"{word}" is an offensive term for Albanian people',
+    words: ['shiptar']
   }
 ];


### PR DESCRIPTION
If we have words for Macedonians, we should have the offensive word for Albanians on the blocklist.